### PR TITLE
added SPVLoc (ECCV 2024)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ If you believe this list is missing something or has factually inaccurate info, 
 ## Camera Pose Regression
 
 - [2025 CVPR] Reloc3r: Large-Scale Training of Relative Camera Pose Regression for Generalizable, Fast, and Accurate Visual Localization [[paper]](https://arxiv.org/pdf/2412.08376) [[code]](https://github.com/ffrivera0/reloc3r)
+- [2024 ECCV] SPVLoc: Semantic Panoramic Viewport Matching for 6D Camera Localization in Unseen Environments [[paper]](https://arxiv.org/pdf/2404.10527) [[code]](https://fraunhoferhhi.github.io/spvloc/)
 - [2024 ECCV] Learning Neural Volumetric Pose Features for Camera Localization [[paper]](https://arxiv.org/pdf/2403.12800)
 - [2024 CVPR] Map-Relative Pose Regression for Visual Re-Localization [[paper]](https://arxiv.org/pdf/2404.09884) [[code]](https://github.com/nianticlabs/marepo)
 - [2023 AAAI] RobustLoc: Robust Camera Pose Regression in Challenging Driving Environments [[paper]](https://arxiv.org/pdf/2211.11238.pdf) [[code]](https://github.com/sijieaaa/RobustLoc)


### PR DESCRIPTION
Hi Siyan,

I suggest adding SPVLoc, a method for 6D camera pose estimation using minimalist indoor 3D models. It regresses relative poses against ranked rendered references. Due to its hybrid approach, it may be a good fit under _Camera Pose Regression_, though it could also be categorized under _Image Retrieval_.

Best,
Niklas
